### PR TITLE
Version 0.3.3 - Changed `specimenType` to be an array rather than a single value on the primary estimate and the subestimate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,5 @@
 
 ## Version 0.3.3 - August 11th 2024
 
-- [BREAKING] Changed `specimenType` on `BasicPrimaryMersEstimateInformation` to be an array of strings rather than a nullable string.
-- [BREAKING] Changed `specimenType` on `MersSampleTypeSubEstimate` to be an array of strings.
+- [BREAKING] Changed `specimenType` on `BasicPrimaryMersEstimateInformation` to be a mandatory array of strings rather than an optional string.
+- [BREAKING] Changed `specimenType` on `MersSampleTypeSubEstimate` to be an array of strings rather than a mandatory string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,8 @@
 
 - [BREAKING] `partitionKey` is passed as a query parameter rather than in the body for `/fao/merstracker-primary-estimates`
 - [BREAKING] `/fao/merstracker-primary-estimates` is transformed back into a `GET` request.
+
+## Version 0.3.3 - August 11th 2024
+
+- [BREAKING] Changed `specimenType` on `BasicPrimaryMersEstimateInformation` to be an array of strings rather than a nullable string.
+- [BREAKING] Changed `specimenType` on `MersSampleTypeSubEstimate` to be an array of strings.

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -67,7 +67,7 @@ interface MersEstimateDocumentBase {
   sampleDenominator: number | undefined;
   sampleNumerator: number | undefined;
   assay: string[];
-  specimenType: string | undefined;
+  specimenType: string[];
   sex: string | undefined;
   isotypes: string[];
   samplingStartDate: Date | undefined;
@@ -223,7 +223,7 @@ type MersTimeFrameSubEstimate = MersSubEstimateBase & {
 }
 
 type MersSampleTypeSubEstimate = MersSubEstimateBase & {
-  specimenType: string;
+  specimenType: string[];
 }
 
 type MersOccupationSubEstimate = MersSubEstimateBase & {

--- a/swagger.json
+++ b/swagger.json
@@ -404,24 +404,27 @@
             }
           },
           "specimenType": {
-            "type": "string",
-            "description": "The type of specimen extracted for the test",
-            "enum": [
-              "Dried Blood",
-              "Not reported",
-              "Plasma",
-              "Multiple Types",
-              "Serum",
-              "Whole Blood",
-              "Saliva",
-              "Nasal Swab or NP",
-              "Rectal swab",
-              "Milk",
-              "Urine",
-              "Muscle",
-              "Throat swab or OP"
-            ],
-            "example": "Serum"
+            "type": "array",
+            "description": "The type(s) of specimen extracted for the test",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Dried Blood",
+                "Not reported",
+                "Plasma",
+                "Multiple Types",
+                "Serum",
+                "Whole Blood",
+                "Saliva",
+                "Nasal Swab or NP",
+                "Rectal swab",
+                "Milk",
+                "Urine",
+                "Muscle",
+                "Throat swab or OP"
+              ],
+              "example": "Serum"
+            }
           },
           "sex": {
             "type": "string",
@@ -1222,24 +1225,27 @@
             ],
             "properties": {
               "specimenType": {
-                "type": "string",
-                "description": "The type of specimen extracted for the test",
-                "enum": [
-                  "Dried Blood",
-                  "Not reported",
-                  "Plasma",
-                  "Multiple Types",
-                  "Serum",
-                  "Whole Blood",
-                  "Saliva",
-                  "Nasal Swab or NP",
-                  "Rectal swab",
-                  "Milk",
-                  "Urine",
-                  "Muscle",
-                  "Throat swab or OP"
-                ],
-                "example": "Serum"
+                "type": "array",
+                "description": "The type(s) of specimen extracted for the test",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "Dried Blood",
+                    "Not reported",
+                    "Plasma",
+                    "Multiple Types",
+                    "Serum",
+                    "Whole Blood",
+                    "Saliva",
+                    "Nasal Swab or NP",
+                    "Rectal swab",
+                    "Milk",
+                    "Urine",
+                    "Muscle",
+                    "Throat swab or OP"
+                  ],
+                  "example": "Dried Blood"
+                }
               }
             }
           }

--- a/swagger.json
+++ b/swagger.json
@@ -207,6 +207,7 @@
           "sourceType",
           "sourceTitle",
           "assay",
+          "specimenType",
           "isotypes",
           "testProducer",
           "testValidation"


### PR DESCRIPTION
Changed `specimenType` to be an array rather than a single value on the primary estimate and the subestimate.