### PR TITLE
Patched version number in `swagger.json` and `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merstracker-partner-api",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merstracker-partner-api",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "express": "^4.19.2",
         "mongodb": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merstracker-partner-api",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "MERSTracker Partner API Documentation",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "schemes": ["https"],
   "servers": [{ "url": "https://merstracker-partner-api.vercel.app" }],


### PR DESCRIPTION
Accidentally forgot to patch version numbers in the latest release.